### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories(                                                            
     ${PROJECT_SOURCE_DIR}/hyrise/src/lib/                                                           #
     ${PROJECT_SOURCE_DIR}/hyrise/third_party/sql-parser/src                                         #
     ${TBB_INCLUDE_DIR}                                                                              #
-    ${Boost_INCLUDE_DIRS}                                                                           #
+    ${Boost_INCLUDE_DIR}                                                                           #
 )                                                                                                   #
                                                                                                     #
 # Global flags and include directories                                                              #


### PR DESCRIPTION
Working on my fork currently. As soon as boost is "really needed", it is not found. Should be `Boost_INCLUDE_DIR`.
I am somewhat surprised that this is not an error.
